### PR TITLE
Fix Grafana dashboard configuration

### DIFF
--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -22,3 +22,16 @@
         "targets": [
           {
             "expr": "(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes * 100",
+            "legendFormat": "Memory",
+            "refId": "B"
+          }
+        ],
+        "gridPos": { "x": 0, "y": 6, "w": 12, "h": 6 }
+      }
+    ],
+    "schemaVersion": 16,
+    "title": "System Dashboard",
+    "version": 1
+  },
+  "overwrite": true
+}


### PR DESCRIPTION
## Summary
- fix truncated Grafana dashboard
- rename grafana-dashboard.js to grafana-dashboard.json

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('grafana-dashboard.json','utf8')); console.log('ok');"`
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684144e380b0832aaaa142dfc8c69aac